### PR TITLE
use lowercased list argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ async function main ({ key, token }, { boardName, since, member, listName, label
 
   const members = await getBoardMembers({ key, token }, boardId)
   let lists = await getBoardLists({ key, token }, boardId)
-  lists = listName ? lists.filter(l => listName && l.name.toLowerCase().includes(listName)) : lists
+  lists = listName ? lists.filter(l => listName && l.name.toLowerCase().includes(listName.toLowerCase())) : lists
   const listsSorted = lists.sort((l1, l2) => l1.pos - l2.pos)
 
   let cards = await getBoardCards({ key, token }, { boardId, since })


### PR DESCRIPTION
Fixes a bug where using a non-lowercased list name (i.e. "Done"), returns no results even if a matching "Done" list name is returned. This was caused by a `toLowerCase` being used on the return list name results but not the list argument.